### PR TITLE
Update rules around custom headers

### DIFF
--- a/chapters/changelog.adoc
+++ b/chapters/changelog.adoc
@@ -17,6 +17,7 @@ to see a list of all changes.
 [[rule-changes]]
 == Rule Changes
 
+* `2022-03-21`: Updated custom headers <<183>> and removed <<233>>
 * `2021-12-09`: event id must not change in retry situations when producers <<211>>.
 * `2021-11-24`: restructuring of the document and some rules.
 * `2021-10-18`: new rule <<244>>.

--- a/chapters/http-headers.adoc
+++ b/chapters/http-headers.adoc
@@ -16,8 +16,8 @@ to make this explicitly visible -- use the parameter definitions of the resource
 [#133]
 == {MAY} use standard headers
 
-Use http://en.wikipedia.org/wiki/List_of_HTTP_header_fields[this list] and
-explicitly mention its support in your OpenAPI definition.
+Use https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Standard_request_fields[this list]
+and explicitly mention its support in your OpenAPI definition.
 
 
 [#132]
@@ -304,7 +304,7 @@ Zalando landscape specific proprietary headers.
 
 
 [#183]
-== {SHOULD} use only the specified proprietary Zalando headers
+== {SHOULD} use only the specified proprietary Owlet headers
 
 As a general rule, proprietary HTTP headers should be avoided.
 From a conceptual point of view, the business semantics and intent of an
@@ -314,111 +314,43 @@ Headers are typically used to implement protocol processing aspects, such as flo
 content negotiation, and authentication, and represent business agnostic
 request modifiers that provide generic context information ({RFC-7231}#section-5[RFC 7231]).
 
-However, the exceptional usage of proprietary headers is still helpful
-when domain-specific generic context information...
+However, the exceptional usage of proprietary headers is still helpful for specific cases:
 
-. needs to be passed end to end along the service call chain (even if
-not all called services use it as input for steering service behavior
-e.g. {X-Sales-Channel} header) and/or...
-. is provided by specific gateway components, for instance, our
-Fashion Shop API or Merchant API gateway.
+. PII safe queries (e.g. {Owlet-Query}, see <<1000, PII Safe
+Search>>) and/or...
+. Modifying a
+https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name[forbidden], or
+https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name#sect1[prerviously forbidden]
+header. (e.g. Chrome/Safari disallowing a custom User-Agent.)
 
 Below, we explicitly define the list of proprietary header exceptions usable for
-all services for passing through generic context information of our fashion domain (use case 1).
+all services.
 
-Per convention, non standardized, proprietary header names are prefixed with  `X-`.
-(Due to backward compatibility, we do not follow the Internet Engineering Task Force’s
-recommendation in {RFC-6648}[RFC 6648] to deprecate usage of  `X-` headers.)
-Remember that HTTP header field names are not case-sensitive:
+Custom headers are prefixed with the organization's name (e.g. Owlet-) as
+reccomended in {RFC-6648}[RFC 6648].  Previous IETF reccomendation was to
+prefix with `X-`, but that has since been deprecated.
 
 [cols="15%,10%,60%,15%",options="header",]
 |=======================================================================
 |Header field name |Type |Description |Header field value example
 
-|[[x-flow-id]]{X-Flow-ID}|String|
-For more information see <<233>>.
-|GKY7oDhpSiKY_gAAAABZ_A
-
-|[[x-tenant-id]]{X-Tenant-ID}|String|
-Identifies the tenant initiated the request
-to the multi tenant Zalando Platform. The {X-Tenant-ID} must be set
-according to the Business Partner ID extracted from the OAuth token when
-a request from a Business Partner hits the Zalando Platform.
-|9f8b3ca3-4be5-436c-a847-9cd55460c495
-
-|[[x-sales-channel]]{X-Sales-Channel}|String|
-Sales channels are owned by retailers and represent a specific consumer segment
-being addressed with a specific product assortment that is offered via CFA
-retailer catalogs to consumers (see {glossary}[fashion platform glossary (internal_link)]).
-|52b96501-0f8d-43e7-82aa-8a96fab134d7
-
-|[[x-frontend-type]]{X-Frontend-Type}|String|
-Consumer facing applications (CFAs) provide business experience to their
-customers via different frontend application types, for instance, mobile app
-or browser. Info should be passed-through as generic aspect -- there are
-diverse concerns, e.g. pushing mobiles with specific coupons, that make use of
-it. Current range is mobile-app, browser, facebook-app, chat-app, email.
-|mobile-app
-
-|[[x-device-type]]{X-Device-Type}|String|
-There are also use cases for steering customer experience (incl. features and
-content) depending on device type. Via this header info should be passed-through
-as generic aspect. Current range is smartphone, tablet, desktop, other.
-|tablet
-
-|[[x-device-os]]{X-Device-OS}|String|
-On top of device type above, we even want to differ between device platform,
-e.g. smartphone Android vs. iOS. Via this header info should be passed-through
-as generic aspect. Current range is iOS, Android, Windows, Linux, MacOS.
-|Android
-
-|[[x-mobile-advertising-id]]{X-Mobile-Advertising-Id}|String|
-It is either the
-https://developer.apple.com/documentation/adsupport/asidentifiermanager[IDFA]
-(Apple Identifier for mobile Advertising) for iOS, or the
-https://support.google.com/googleplay/android-developer/answer/6048248[GAID]
-(Google mobile Advertising Identifier) for Android. It is a unique,
-customer-resettable identifier provided by mobile device’s operating system
-to facilitate personalized advertising, and usually passed by mobile apps via http header
-when calling backend services. Called services should be ready to pass this
-parameter through when calling other services. It is not sent if the customer
-disables it in the settings for respective mobile platform.
-|b89fadce-1f42-46aa-9c83-b7bc49e76e1f
+|[[owlet-query]]{Owlet-Query}|String|
+Used to send a query parameter that contians PII.
+|(firstName = Jane) AND (lastName = Doe)
+|[[owlet-user-agent]]{Owlet-User-Agent}|String|
+Used to send a custom user agent from browsers on which it is not supported.
+|OwletWebApp/1.0.1 (iPhone, iOS 15.3.1)
 
 |=======================================================================
 
 *Exception:* The only exception to this guideline are the conventional
 hop-by-hop `X-RateLimit-` headers which can be used as defined in <<153>>.
 
-As part of the guidelines we sourced the OpenAPI definition of all proprietary headers;
-you can simply reference it when defining the API endpoint requests e.g.
-[source,yaml]
-----
-parameters:
-- $ref: "https://opensource.zalando.com/restful-api-guidelines/models/request-headers-1.0.0.yaml#/X-Flow-ID"
-- $ref: "https://opensource.zalando.com/restful-api-guidelines/models/request-headers-1.0.0.yaml#/X-Tenant-ID"
-----
-
-Response headers can be referenced in the API endpoint e.g.
-[source,yaml]
-----
-parameters:
-- $ref: "https://opensource.zalando.com/restful-api-guidelines/models/response-headers-1.0.0.yaml#/ETag"
-- $ref: "https://opensource.zalando.com/restful-api-guidelines/models/response-headers-1.0.0.yaml#/Cache-Control"
-----
-
-*Hint:* This guideline does not standardize proprietary headers for 
-our specific gateway components (2. use case above). 
-This include, for instance, non pass-through headers `X-Zalando-Client-ID`, `X-Zalando-Request-Host`, 
-`X-Zalando-Request-URI` defined by Fashion Shop API (RKeep), or `X-Consumer`, `X-Consumer-Signature`, 
-`X-Consumer-Key-ID` defined by Merchant API gateway. 
-All these proprietary headers are allowlisted in the API Linter (Zally) checking this rule.
-
 
 [#184]
 == {MUST} propagate proprietary headers
 
-All Zalando's proprietary headers listed above are end-to-end headers
+All Owlet's proprietary headers listed above are end-to-end headers
 footnote:header-types[HTTP/1.1 standard ({RFC-7230}#section-6.1[RFC 7230])
 defines two types of headers: end-to-end and hop-by-hop headers. End-to-end
 headers must be transmitted to the ultimate recipient of a request or response.
@@ -427,73 +359,7 @@ only.]
 and must be propagated to the services down the call
 chain. The header names and values must remain unchanged.
 
-For example, the values of the custom headers like {X-Device-Type} can affect
-the results of queries by using device type information to influence
-recommendation results. Besides, the values of the custom headers can influence
-the results of the queries (e.g. the device type information influences the
-recommendation results).
-
 Sometimes the value of a proprietary header will be used as part of the entity
 in a subsequent request. In such cases, the proprietary headers must still be
 propagated as headers with the subsequent request, despite the duplication of
 information.
-
-
-[#233]
-== {MUST} support X-Flow-ID
-
-The {Flow-ID} is a generic parameter to be passed through service APIs and
-events and written into log files and traces. A consequent usage of the
-{Flow-ID} facilitates the tracking of call flows through our system and allows
-the correlation of service activities initiated by a specific call. This is
-extremely helpful for operational troubleshooting and log analysis. Main use
-case of {Flow-ID} is to track service calls of our SaaS fashion commerce
-platform and initiated internal processing flows (executed synchronously via
-APIs or asynchronously via published events).
-
-
-=== Data Definition
-
-The {Flow-ID} must be passed through:
-
-* RESTful API requests via {X-Flow-ID} proprietary header (see <<184>>)
-* Published events via `flow_id` event field (see <<event-metadata, metadata>>)
-
-The following formats are allowed:
-
-* `UUID` ({RFC-4122}[RFC-4122])
-* `base64` ({RFC-4648}[RFC-4648])
-* `base64url` ({RFC-4648}#section-5[RFC-4648 Section 5])
-* Random unique string restricted to the character set `[a-zA-Z0-9/+_-=]` maximal of 128 characters.
-
-*Note:* If a legacy subsystem can only process `Flow-IDs` with a specific
-format or length, it must define this restrictions in its API specification,
-and be generous and remove invalid characters or cut the length to the
-supported limit.
-
-*Hint:* In case distributed tracing is supported by 
-{SRE-open-tracing}[OpenTracing (internal_link)] 
-you should ensure that created _spans_ are tagged using `flow_id` — see
-{SRE-open-tracing}/blob/master/wg-semantic-conventions/best-practices/flowid.md[How to Connect Log Output with OpenTracing Using Flow-IDs (internal_link)] 
-or
-{SRE-open-tracing}/blob/master/wg-semantic-conventions/best-practices.md[Best practises (internal_link)].
-
-=== Service Guidance
-
-* Services *must* support {Flow-ID} as generic input, i.e.
-** RESTful API endpoints *must* support {X-Flow-ID} header in requests
-** Event listeners *must* support the metadata `flow-id` from events.
-
-+
-*Note:* API-Clients *must* provide {Flow-ID} when calling a service or
-producing events. If no {Flow-ID} is provided in a request or event, the
-service must create a new {Flow-ID}.
-
-* Services *must* propagate {Flow-ID}, i.e. use {Flow-ID} received
-with API calls or consumed events as...
-** input for all API called and events published during processing
-** data field written for logging and tracing
-
-*Hint:* This rule also applies to application internal interfaces and events
-not published via Nakadi (but e.g. via AWS SQS, Kinesis or service specific
-DB solutions).

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -314,6 +314,7 @@ can take for header information:
 * Return a trio of `X-RateLimit` headers. These headers (described below) allow
   a server to express a service level in the form of a number of allowing
   requests within a given window of time and when the window is reset.
+  <!-- If adjusting X-RateLimit rules, see also rule #183 -->
 
 The `X-RateLimit` headers are:
 

--- a/index.adoc
+++ b/index.adoc
@@ -165,15 +165,8 @@
 
 // Attributes to improve linking to special definition anchors.
 :Idempotency-Key: pass:[<a href="#230"><code>Idempotency-Key</code></a>]
-:X-Flow-ID: pass:[<a href="#x-flow-id"><code>X-Flow-ID</code></a>]
-:X-Tenant-ID: pass:[<a href="#x-tenant-id"><code>X-Tenant-ID</code></a>]
-:X-Sales-Channel: pass:[<a href="#x-sales-channel"><code>X-Sales-Channel</code></a>]
-:X-Frontend-Type: pass:[<a href="#x-frontend-type"><code>X-Frontend-Type</code></a>]
-:X-Device-Type: pass:[<a href="#x-device-type"><code>X-Device-Type</code></a>]
-:X-Device-OS: pass:[<a href="#x-device-os"><code>X-Device-OS</code></a>]
-:X-Mobile-Advertising-ID: pass:[<a href="#x-mobile-advertising-id"><code>X-Mobile-Advertising-ID</code></a>]
-:X-App-Domain: pass:[<a href="#x-app-domain"><code>X-App-Domain</code></a>]
-
+:Owlet-Query: pass:[<a href="#owlet-query"><code>Owlet-Query</code></a>]
+:Owlet-User-Agent: pass:[<a href="#owlet-user-agent"><code>Owlet-User-Agent</code></a>]
 :x-extensible-enum: pass:[<a href="#112"><code>x-extensible-enum</code></a>]
 
 

--- a/models/request-headers-1.0.0.yaml
+++ b/models/request-headers-1.0.0.yaml
@@ -1,78 +1,9 @@
-X-Flow-ID:
-  name: X-Flow-ID
+Owlet-Query:
+  name: Owlet-Query
   description: |
-      A custom header that will be passed onto any further requests and can be used for investigation in error cases.
+    A custom header to be used when a query must contain PII and must also be
+    sent via query parameters.
   in: header
   schema:
     type: string
-    example: GKY7oDhpSiKY_gAAAABZ_A
-
-X-Mobile-Advertising-ID:
-  in: header
-  name: X-Mobile-Advertising-ID
-  description: >
-    It is a unique, customer-resettable identifier provided by mobile device’s operating system to facilitate
-    personalized advertising, and usually passed by mobile apps via http header when calling backend services.
-    It is either the [IDFA](https://developer.apple.com/documentation/adsupport/asidentifiermanager)
-    (Apple Identifier for mobile Advertising) for iOS, or the
-    [GAID](https://support.google.com/googleplay/android-developer/answer/6048248) (Google mobile Advertising Identifier)
-     for Android.
-  schema:
-    type: string
-    example: cdda802e-fb9c-47ad-0794d394c912
-
-X-Tenant-ID:
-  name: X-Tenant-ID
-  description: |
-    Identifies the tenant initiated the request to the multi tenant Zalando Platform. The X-Tenant-ID must be set
-     according to the Business Partner ID extracted from the OAuth token when a request from a Business Partner
-     hits the Zalando Platform.
-  in: header
-  schema:
-    type: string
-    example: 9f8b3ca3-4be5-436c-a847-9cd55460c495
-
-X-Sales-Channel:
-  name: X-Sales-Channel
-  description: |
-    Sales channels are owned by retailers and represent a specific consumer segment being addressed with a
-    specific product assortment that is offered via CFA retailer catalogs to consumers (see fashion platform
-    glossary (internal link))
-  in: header
-  schema:
-    type: string
-    example: 52b96501-0f8d-43e7-82aa-8a96fab134d7
-
-X-Frontend-Type:
-  name: X-Frontend-Type
-  description: |
-    Consumer facing applications (CFAs) provide business experience to their customers via different
-    frontend application types, for instance, mobile app or browser. Info should be passed-through as
-    generic aspect — there are diverse concerns, e.g. pushing mobiles with specific coupons, that make use
-    of it. Current range is mobile-app, browser, facebook-app, chat-app, email.
-  in: header
-  schema:
-    type: string
-    example: mobile-app
-
-X-device-Type:
-  name: X-device-Type
-  description: |
-    There are also use cases for steering customer experience (incl. features and content) depending on
-    device type. Via this header info should be passed-through as generic aspect. Current range is
-    smartphone, tablet, desktop, other.
-  in: header
-  schema:
-    type: string
-    example: tablet
-
-X-device-OS:
-  name: X-device-OS
-  description: |
-    On top of device type above, we even want to differ between device platform, e.g. smartphone
-    Android vs. iOS. Via this header info should be passed-through as generic aspect.
-    Current range is iOS, Android, Windows, Linux, MacOS.
-  in: header
-  schema:
-    type: string
-    example: Android
+    example: (firstName = Jane) AND (lastName = Doe)

--- a/models/response-headers-1.0.0.yaml
+++ b/models/response-headers-1.0.0.yaml
@@ -1,12 +1,3 @@
-X-Flow-ID:
-  name: X-Flow-ID
-  description: |
-      A custom header that will be passed onto any further requests and can be used for investigation in error cases.
-  in: header
-  schema:
-    type: string
-    example: GKY7oDhpSiKY_gAAAABZ_A
-
 Cache-Control:
   in: header
   name: Cache-Control


### PR DESCRIPTION
Owlet custom headers follow a different format, and we have a list of
explicitly allowed custom headers. Cleaned up the Zalando proprietary
headers.

NOTE: this links to rule #1000, which doesn't yet exist. It's a different ticket and a different PR. Rule #1000 is mine. Don't use it. I called dibs.